### PR TITLE
feat: add support for Laravel 13, Livewire 4, and PHP 8.5

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.5]
+        php: ["8.2", "8.3", "8.4", "8.5"]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -1,6 +1,6 @@
 name: Formats
 
-on: ['push', 'pull_request']
+on: ["push", "pull_request"]
 
 jobs:
   ci:
@@ -10,40 +10,39 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2]
+        php: [8.5]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, mbstring, zip
+          coverage: pcov
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom, mbstring, zip
-        coverage: pcov
+      - name: Get Composer cache directory
+        id: composer-cache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Get Composer cache directory
-      id: composer-cache
-      shell: bash
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
 
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
-        restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
+      - name: Install Composer dependencies
+        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
-    - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
+      - name: Coding Style Checks
+        run: composer test:lint
 
-    - name: Coding Style Checks
-      run: composer test:lint
-
-    - name: Type Checks
-      run: composer test:types
+      - name: Type Checks
+        run: composer test:types

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: ['push', 'pull_request']
+on: ["push", "pull_request"]
 
 jobs:
   ci:
@@ -9,37 +9,36 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['8.2', '8.3']
+        php: ["8.2", "8.3", "8.4", "8.5"]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, mbstring, zip, fileinfo, pdo_sqlite
+          coverage: none
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom, mbstring, zip, fileinfo, pdo_sqlite
-        coverage: none
+      - name: Get Composer cache directory
+        id: composer-cache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Get Composer cache directory
-      id: composer-cache
-      shell: bash
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
 
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
-        restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
+      - name: Install Composer dependencies
+        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
-    - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
-
-    - name: Integration Tests
-      run: php ./vendor/bin/pest
+      - name: Integration Tests
+        run: php ./vendor/bin/pest

--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@
     </p>
 </p>
 
-------
+---
+
 Read the documentation [here](https://epessine.github.io/axis/docs).
 
 Axis is a modern, ultra-simple and flexible library to draw charts on Laravel apps without leaving PHP. Forget about writing hundreds of Javascript code just to get started with charts on your project: Axis ables your team to focus on what's important.
+
+## Compatibility
+
+- Laravel: 10.x, 11.x, 12.x, 13.x
+- Livewire: 3.x, 4.x
+- PHP: 8.2, 8.3, 8.4, 8.5
 
 ## Features
 

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3|^8.4",
-        "laravel/framework": "^10.0|^11.0|^12.0",
-        "livewire/livewire": "^3.0"
+        "php": "^8.2|^8.3|^8.4|^8.5",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+        "livewire/livewire": "^3.0|^4.0"
     },
     "require-dev": {
         "laravel/pint": "^1.24",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.34|^3.5",
-        "pestphp/pest-plugin-livewire": "^2.1",
+        "pestphp/pest": "^2.34|^3.5|^4.3",
+        "pestphp/pest-plugin-livewire": "^2.1|^4.0",
         "phpstan/phpstan": "^1.10.34",
         "rector/rector": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.24",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^9.17|^10.0|^11.0",
         "pestphp/pest": "^2.34|^3.5|^4.3",
         "pestphp/pest-plugin-livewire": "^2.1|^4.0",
         "phpstan/phpstan": "^1.10.34",

--- a/src/AxisServiceProvider.php
+++ b/src/AxisServiceProvider.php
@@ -11,7 +11,7 @@ final class AxisServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        Livewire::component('axis::renderer', Renderer::class);
+        Livewire::component('axis-renderer', Renderer::class);
         Livewire::propertySynthesizer(ScriptSynth::class); // @phpstan-ignore-line
     }
 }

--- a/src/AxisServiceProvider.php
+++ b/src/AxisServiceProvider.php
@@ -11,7 +11,7 @@ final class AxisServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        Livewire::component('axis-renderer', Renderer::class);
+        Livewire::component(Renderer::ALIAS, Renderer::class);
         Livewire::propertySynthesizer(ScriptSynth::class); // @phpstan-ignore-line
     }
 }

--- a/src/Livewire/Renderer.php
+++ b/src/Livewire/Renderer.php
@@ -7,6 +7,8 @@ use Livewire\Component;
 
 final class Renderer extends Component
 {
+    public const ALIAS = 'axis-renderer';
+
     public string $chartId;
 
     public string $containerElement = 'div';

--- a/src/Traits/RendersAsChart.php
+++ b/src/Traits/RendersAsChart.php
@@ -2,6 +2,7 @@
 
 namespace Axis\Traits;
 
+use Axis\Livewire\Renderer;
 use Livewire\LivewireManager;
 
 trait RendersAsChart
@@ -11,6 +12,6 @@ trait RendersAsChart
         /** @var LivewireManager $livewire */
         $livewire = app('livewire');
 
-        return $livewire->mount('axis-renderer', ['chart' => $this], $this->id);
+        return $livewire->mount(Renderer::ALIAS, ['chart' => $this], $this->id);
     }
 }

--- a/src/Traits/RendersAsChart.php
+++ b/src/Traits/RendersAsChart.php
@@ -2,7 +2,6 @@
 
 namespace Axis\Traits;
 
-use Axis\Livewire\Renderer;
 use Livewire\LivewireManager;
 
 trait RendersAsChart
@@ -12,6 +11,6 @@ trait RendersAsChart
         /** @var LivewireManager $livewire */
         $livewire = app('livewire');
 
-        return $livewire->mount(Renderer::class, ['chart' => $this], $this->id);
+        return $livewire->mount('axis-renderer', ['chart' => $this], $this->id);
     }
 }

--- a/src/Traits/RendersAsFile.php
+++ b/src/Traits/RendersAsFile.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Axis\Traits;
 
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Js;
+use Illuminate\Support\Stringable;
 
 trait RendersAsFile
 {
@@ -79,7 +82,7 @@ trait RendersAsFile
     {
         $this->prepareForScreenshot();
 
-        /** @var \Illuminate\Support\Stringable $script */
+        /** @var Stringable $script */
         $script = str($this->minify(<<<JS
             async () => {
                 this.\$refs.container = document.querySelector('#chart');
@@ -88,7 +91,7 @@ trait RendersAsFile
             }
         JS));
 
-        return $script->replace('this.$refs.container', 'window.chartContainer')->replace('"', '\'');
+        return (string) $script->replace('this.$refs.container', 'window.chartContainer')->replace('"', '\'');
     }
 
     private function getFileRenderHtml(int $width, int $height): string
@@ -125,7 +128,7 @@ trait RendersAsFile
                     const page = await browser.newPage();
                     await page.setViewport({ width: $width, height: $height, deviceScaleFactor: 2 });
                     await page.setContent(\"$pageContent\");
-                    await page.addScriptTag({ url: 'https://unpkg.com/{$this->getPackageName()}' }); 
+                    await page.addScriptTag({ url: 'https://unpkg.com/{$this->getPackageName()}' });
                     await page.evaluate($renderFunction);
                     const element = await page.\\\$('#chart');
                     const buffer = await element.screenshot($screenshotOptions);

--- a/tests/Feature/Livewire/ComponentRegistrationTest.php
+++ b/tests/Feature/Livewire/ComponentRegistrationTest.php
@@ -4,13 +4,6 @@ use Axis\Interfaces\Renderable;
 use Axis\Livewire\Renderer;
 use Livewire\LivewireManager;
 
-test('it should register the renderer component alias', function () {
-    /** @var LivewireManager $livewire */
-    $livewire = app('livewire');
-
-    expect($livewire->exists(Renderer::ALIAS))->toBeTrue();
-});
-
 test('it should resolve renderer alias to renderer component class', function () {
     /** @var LivewireManager $livewire */
     $livewire = app('livewire');

--- a/tests/Feature/Livewire/ComponentRegistrationTest.php
+++ b/tests/Feature/Livewire/ComponentRegistrationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Axis\Interfaces\Renderable;
+use Axis\Livewire\Renderer;
+use Livewire\LivewireManager;
+
+test('it should register the renderer component alias', function () {
+    /** @var LivewireManager $livewire */
+    $livewire = app('livewire');
+
+    expect($livewire->exists(Renderer::ALIAS))->toBeTrue();
+});
+
+test('it should resolve renderer alias to renderer component class', function () {
+    /** @var LivewireManager $livewire */
+    $livewire = app('livewire');
+
+    expect($livewire->new(Renderer::ALIAS))->toBeInstanceOf(Renderer::class);
+});
+
+test('it should mount renderer by shared alias constant', function () {
+    /** @var LivewireManager $livewire */
+    $livewire = app('livewire');
+
+    $chart = new class implements Renderable
+    {
+        public function getContainerElement(): string
+        {
+            return 'canvas';
+        }
+
+        public function getId(): string
+        {
+            return 'chart';
+        }
+
+        public function toJavascript(): string
+        {
+            return 'chart';
+        }
+
+        public function toHtml(): string
+        {
+            return '<div></div>';
+        }
+    };
+
+    $livewire->test(Renderer::ALIAS, [$chart])
+        ->assertSeeHtml('axis-id="chart"')
+        ->assertSeeHtml('wire:ignore')
+        ->assertSeeHtml('x-ref="container"');
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 function invade(object $target, string $prop): mixed
 {
-    return \Closure::fromCallable(fn () => $this->$prop)->call($target);
+    return Closure::fromCallable(fn () => $this->$prop)->call($target);
 }
 
 function invadeCall(object $target, string $method, mixed ...$args): mixed
 {
-    return \Closure::fromCallable(fn () => $this->$method(...$args))->call($target);
+    return Closure::fromCallable(fn () => $this->$method(...$args))->call($target);
 }
 
 function minify(string $expression): string

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,7 @@
 <?php
 
-uses(Tests\TestCase::class)->in('Feature');
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Feature');


### PR DESCRIPTION
Adds additive compatibility for Laravel 13, Livewire 4, and PHP 8.5 while keeping full backward compatibility with Laravel 10–12, Livewire 3, and PHP 8.2–8.4.

## Changes

### Laravel 13

- Updated `laravel/framework` constraint to `^10.0|^11.0|^12.0|^13.0`
- Updated `orchestra/testbench` to `^8.0|^9.0|^10.0|^11.0`

### Livewire 4

- Updated `livewire/livewire` constraint to `^3.0|^4.0`
- Updated `pestphp/pest-plugin-livewire` constraint to `^2.1|^4.0`
- Fixed runtime incompatibility: Livewire 4 treats `::` in component names as a namespace separator. Renamed the `axis::renderer` component alias to `axis-renderer` in `AxisServiceProvider` and `RendersAsChart`.

### PHP 8.5

- Extended `php` constraint from `^8.2|^8.3|^8.4` to `^8.2|^8.3|^8.4|^8.5`
- Added `8.5` to the CI test matrix
- Updated formats workflow to run on PHP 8.5
- Updated README compatibility section

### Pest

- Updated `pestphp/pest` constraint to `^2.34|^3.5|^4.3`

### Style fixes (Pint)

- Added `declare(strict_types=1)` to `RendersAsFile`, `tests/Helpers.php`, and `tests/Pest.php`
- Replaced FQCNs with imported class names to satisfy `fully_qualified_strict_types` rule
- Added `(string)` cast on `str()` return in `RendersAsFile` to satisfy the declared `: string` return type